### PR TITLE
修改了Sparklite版本的异常问题

### DIFF
--- a/src/main/java/io/github/briqt/spark4j/constant/SparkApiVersion.java
+++ b/src/main/java/io/github/briqt/spark4j/constant/SparkApiVersion.java
@@ -11,7 +11,7 @@ public enum SparkApiVersion {
     /**
      * 1.5版本
      */
-    V1_5("v1.1", "https://spark-api.xf-yun.com/v1.1/chat", "general"),
+    V1_5("v1.1", "https://spark-api.xf-yun.com/v1.1/chat", "lite"),
 
     /**
      * 2.0版本


### PR DESCRIPTION
官方文档中Spark lite对应的domain参数为lite，之前版本中写的是general，在实际调用Spark lite的时候会报错